### PR TITLE
[Video Downloader] Do not use av1 encoding

### DIFF
--- a/src/download_system/downloaders/youtube.py
+++ b/src/download_system/downloaders/youtube.py
@@ -67,14 +67,6 @@ class AlternateYoutubeDownloader(AlternateVideoDownloader):
             'default_search': 'auto',
             'nooverwrites': True,
             'quiet': True,
-            # Add post-processor to re-encode AV1 videos to H.264 if they are downloaded
-            'postprocessors': [{
-                'key': 'FFmpegVideoConvertor',
-                'preferedformat': 'mp4',
-                'when': 'video.codec:av01'
-            }],
-            # Ensure FFmpeg is used for any needed conversions
-            'prefer_ffmpeg': True,
         }
 
         return await cls._get_list_from_ydt(url, costum_options, path)


### PR DESCRIPTION
Fixes #25 by filtering out any option that has AV1 encoding, and if we can't do that, use postprocessing to try to change it back to mp4 which hopefully will change it to h265, only issue this might cause is a lot of CPU usage in the very small cloud VM this is running on. Also, I have not used the postprocessing part of yt-dlp before, and asked Copilot (Claude) for its usage of it. It may be wrong, requires further testing